### PR TITLE
pause and unpause commands for feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work.sum
 .env
 
 hopper.db
+
+# Local testing artifacts (test feeds, throwaway scripts, etc.)
+scratch/

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,3 @@ go.work.sum
 .env
 
 hopper.db
-
-# Local testing artifacts (test feeds, throwaway scripts, etc.)
-scratch/

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/spf13/cobra"
+	_ "modernc.org/sqlite"
+
+	"github.com/nint8835/hopper/pkg/config"
+	"github.com/nint8835/hopper/pkg/database/migrations"
+	"github.com/nint8835/hopper/pkg/feeds"
+)
+
+var refreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Refresh all feeds once and exit. Useful for testing or for impatient operators.",
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg, err := config.Load()
+		checkErr(err, "Failed to load config")
+
+		db, err := sql.Open("sqlite", cfg.DatabasePath+"?_pragma=foreign_keys(1)")
+		checkErr(err, "Failed to connect to database")
+		defer db.Close()
+
+		migrationRunner, err := migrations.New(db)
+		checkErr(err, "Failed to create migration runner")
+		err = migrationRunner.Up()
+		if err != nil && !errors.Is(err, migrate.ErrNoChange) {
+			checkErr(err, "Failed to run migrations")
+		}
+
+		session, err := discordgo.New(fmt.Sprintf("Bot %s", cfg.DiscordToken))
+		checkErr(err, "Failed to create Discord session")
+
+		err = session.Open()
+		checkErr(err, "Failed to open Discord connection")
+		defer func() {
+			if err := session.Close(); err != nil {
+				slog.Error("Failed to close Discord connection", "err", err)
+			}
+		}()
+
+		// Construct the watcher but don't Start() it — we just want a one-shot
+		// refresh, not the scheduled poll loop. Stop() is unsafe to call when
+		// Start() wasn't, so we let the process exit clean up the ticker and
+		// internal context.
+		watcher := feeds.New(cfg, db, session)
+
+		err = watcher.RefreshFeeds(context.Background())
+		if err != nil {
+			slog.Error("Refresh completed with errors", "err", err)
+			return
+		}
+
+		slog.Info("Refresh complete")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(refreshCmd)
+}

--- a/pkg/bot/commands.go
+++ b/pkg/bot/commands.go
@@ -391,6 +391,86 @@ func (b *Bot) handleUnpauseCommand(session *discordgo.Session, i *discordgo.Inte
 	}
 }
 
+type refreshCommandArgs struct {
+	ID *int `description:"Optional ID of the feed to refresh. If omitted, refreshes all feeds."`
+}
+
+func (b *Bot) handleRefreshCommand(session *discordgo.Session, i *discordgo.InteractionCreate, args refreshCommandArgs) {
+	_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{},
+	})
+
+	if args.ID != nil {
+		feed, err := b.Queries.GetFeedByID(context.Background(), int64(*args.ID))
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+					Content: utils.PtrTo(fmt.Sprintf("No feed found with ID `%d`.", *args.ID)),
+				})
+				return
+			}
+
+			b.logger.Error("Failed to get feed", "error", err)
+			_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+				Embeds: utils.PtrTo([]*discordgo.MessageEmbed{
+					{
+						Title:       "Failed to get feed",
+						Description: fmt.Sprintf("```\n%s\n```", err.Error()),
+						Color:       0xff0000,
+					},
+				}),
+			})
+			return
+		}
+
+		err = b.watcher.RefreshFeed(feed, false)
+		if err != nil {
+			b.logger.Error("Failed to refresh feed", "feed_id", feed.ID, "error", err)
+			_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+				Embeds: utils.PtrTo([]*discordgo.MessageEmbed{
+					{
+						Title:       "Failed to refresh feed",
+						Description: fmt.Sprintf("```\n%s\n```", err.Error()),
+						Color:       0xff0000,
+					},
+				}),
+			})
+			return
+		}
+
+		_, err = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Content: utils.PtrTo(fmt.Sprintf("Refreshed **%s**.", feed.Title)),
+		})
+		if err != nil {
+			b.logger.Error("Failed to respond to interaction", "error", err)
+		}
+		return
+	}
+
+	err := b.watcher.RefreshFeeds()
+	if err != nil {
+		b.logger.Error("Failed to refresh feeds", "error", err)
+		_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+			Embeds: utils.PtrTo([]*discordgo.MessageEmbed{
+				{
+					Title:       "Failed to refresh one or more feeds",
+					Description: fmt.Sprintf("```\n%s\n```", err.Error()),
+					Color:       0xff0000,
+				},
+			}),
+		})
+		return
+	}
+
+	_, err = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
+		Content: utils.PtrTo("Refreshed all feeds."),
+	})
+	if err != nil {
+		b.logger.Error("Failed to respond to interaction", "error", err)
+	}
+}
+
 func (b *Bot) registerCommands() {
 	_ = b.parser.AddCommand(&switchboard.Command{
 		Name:        "add",
@@ -420,6 +500,12 @@ func (b *Bot) registerCommands() {
 		Name:        "unpause",
 		Description: "Resume a paused feed",
 		Handler:     b.handleUnpauseCommand,
+		GuildID:     b.config.DiscordGuildId,
+	})
+	_ = b.parser.AddCommand(&switchboard.Command{
+		Name:        "refresh",
+		Description: "Manually trigger a feed refresh (useful for testing)",
+		Handler:     b.handleRefreshCommand,
 		GuildID:     b.config.DiscordGuildId,
 	})
 }

--- a/pkg/bot/commands.go
+++ b/pkg/bot/commands.go
@@ -152,7 +152,13 @@ func (b *Bot) handleAddCommand(session *discordgo.Session, i *discordgo.Interact
 		b.logger.Error("Failed to respond to interaction", "error", err)
 	}
 
-	go b.watcher.RefreshFeed(newFeed, true)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+		if err := b.watcher.RefreshFeed(ctx, newFeed, true); err != nil {
+			b.logger.Error("Failed to backfill new feed", "feed_id", newFeed.ID, "error", err)
+		}
+	}()
 }
 
 func (b *Bot) handleListCommand(session *discordgo.Session, i *discordgo.InteractionCreate, args struct{}) {
@@ -396,13 +402,21 @@ type refreshCommandArgs struct {
 }
 
 func (b *Bot) handleRefreshCommand(session *discordgo.Session, i *discordgo.InteractionCreate, args refreshCommandArgs) {
-	_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	if err := session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{},
-	})
+	}); err != nil {
+		b.logger.Error("Failed to defer interaction response", "error", err)
+		return
+	}
+
+	// Discord interaction tokens expire after 15 minutes; cap the refresh so we
+	// always have time to edit the response with the outcome.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
 
 	if args.ID != nil {
-		feed, err := b.Queries.GetFeedByID(context.Background(), int64(*args.ID))
+		feed, err := b.Queries.GetFeedByID(ctx, int64(*args.ID))
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
@@ -424,7 +438,7 @@ func (b *Bot) handleRefreshCommand(session *discordgo.Session, i *discordgo.Inte
 			return
 		}
 
-		err = b.watcher.RefreshFeed(feed, false)
+		err = b.watcher.RefreshFeed(ctx, feed, false)
 		if err != nil {
 			b.logger.Error("Failed to refresh feed", "feed_id", feed.ID, "error", err)
 			_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
@@ -448,7 +462,7 @@ func (b *Bot) handleRefreshCommand(session *discordgo.Session, i *discordgo.Inte
 		return
 	}
 
-	err := b.watcher.RefreshFeeds()
+	err := b.watcher.RefreshFeeds(ctx)
 	if err != nil {
 		b.logger.Error("Failed to refresh feeds", "error", err)
 		_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{

--- a/pkg/bot/commands.go
+++ b/pkg/bot/commands.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"pkg.nit.so/switchboard"
@@ -172,7 +173,15 @@ func (b *Bot) handleListCommand(session *discordgo.Session, i *discordgo.Interac
 
 	feedStrings := make([]string, 0, len(allFeeds))
 	for _, feed := range allFeeds {
-		feedStrings = append(feedStrings, fmt.Sprintf("- `%d`. **%s** (`%s`)", feed.ID, feed.Title, feed.FeedUrl))
+		pausedSuffix := ""
+		if feed.PausedUntil.Valid && feed.PausedUntil.Time.After(time.Now()) {
+			if feed.PausedUntil.Time.Year() >= 9999 {
+				pausedSuffix = " (paused)"
+			} else {
+				pausedSuffix = fmt.Sprintf(" (paused until <t:%d:f>)", feed.PausedUntil.Time.Unix())
+			}
+		}
+		feedStrings = append(feedStrings, fmt.Sprintf("- `%d`. **%s** (`%s`)%s", feed.ID, feed.Title, feed.FeedUrl, pausedSuffix))
 	}
 
 	err = session.InteractionRespond(
@@ -223,6 +232,165 @@ func (b *Bot) handleRemoveCommand(session *discordgo.Session, i *discordgo.Inter
 	}
 }
 
+type pauseCommandArgs struct {
+	ID       int     `description:"ID of the feed to pause."`
+	Duration *string `description:"Optional duration to pause for (e.g. 1h, 30m, 24h). If not specified, pauses indefinitely."`
+}
+
+// indefinitePauseTime is used to represent an indefinite pause. Far enough in the future
+// to never be reached, but still a valid sql.NullTime.
+var indefinitePauseTime = time.Date(9999, time.December, 31, 23, 59, 59, 0, time.UTC)
+
+func (b *Bot) handlePauseCommand(session *discordgo.Session, i *discordgo.InteractionCreate, args pauseCommandArgs) {
+	feed, err := b.Queries.GetFeedByID(context.Background(), int64(args.ID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: fmt.Sprintf("No feed found with ID `%d`.", args.ID),
+				},
+			})
+			return
+		}
+
+		b.logger.Error("Failed to get feed", "error", err)
+		_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "Failed to get feed",
+						Description: fmt.Sprintf("```\n%s\n```", err.Error()),
+						Color:       0xff0000,
+					},
+				},
+			},
+		})
+		return
+	}
+
+	pausedUntil := indefinitePauseTime
+	durationDisplay := "indefinitely"
+
+	if args.Duration != nil && *args.Duration != "" {
+		duration, err := time.ParseDuration(*args.Duration)
+		if err != nil {
+			_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: fmt.Sprintf("Invalid duration `%s`. Use a Go duration string like `1h`, `30m`, or `24h`.", *args.Duration),
+				},
+			})
+			return
+		}
+		if duration <= 0 {
+			_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: "Duration must be positive.",
+				},
+			})
+			return
+		}
+		pausedUntil = time.Now().Add(duration)
+		durationDisplay = fmt.Sprintf("until <t:%d:f>", pausedUntil.Unix())
+	}
+
+	err = b.Queries.PauseFeed(context.Background(), database.PauseFeedParams{
+		PausedUntil: sql.NullTime{Time: pausedUntil, Valid: true},
+		ID:          feed.ID,
+	})
+	if err != nil {
+		b.logger.Error("Failed to pause feed", "error", err)
+		_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "Failed to pause feed",
+						Description: fmt.Sprintf("```\n%s\n```", err.Error()),
+						Color:       0xff0000,
+					},
+				},
+			},
+		})
+		return
+	}
+
+	err = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("Paused **%s** %s. New items will be silently consumed until resumed.", feed.Title, durationDisplay),
+		},
+	})
+	if err != nil {
+		b.logger.Error("Failed to respond to interaction", "error", err)
+	}
+}
+
+type unpauseCommandArgs struct {
+	ID int `description:"ID of the feed to unpause."`
+}
+
+func (b *Bot) handleUnpauseCommand(session *discordgo.Session, i *discordgo.InteractionCreate, args unpauseCommandArgs) {
+	feed, err := b.Queries.GetFeedByID(context.Background(), int64(args.ID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Content: fmt.Sprintf("No feed found with ID `%d`.", args.ID),
+				},
+			})
+			return
+		}
+
+		b.logger.Error("Failed to get feed", "error", err)
+		_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "Failed to get feed",
+						Description: fmt.Sprintf("```\n%s\n```", err.Error()),
+						Color:       0xff0000,
+					},
+				},
+			},
+		})
+		return
+	}
+
+	err = b.Queries.UnpauseFeed(context.Background(), feed.ID)
+	if err != nil {
+		b.logger.Error("Failed to unpause feed", "error", err)
+		_ = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "Failed to unpause feed",
+						Description: fmt.Sprintf("```\n%s\n```", err.Error()),
+						Color:       0xff0000,
+					},
+				},
+			},
+		})
+		return
+	}
+
+	err = session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: fmt.Sprintf("Resumed **%s**.", feed.Title),
+		},
+	})
+	if err != nil {
+		b.logger.Error("Failed to respond to interaction", "error", err)
+	}
+}
+
 func (b *Bot) registerCommands() {
 	_ = b.parser.AddCommand(&switchboard.Command{
 		Name:        "add",
@@ -240,6 +408,18 @@ func (b *Bot) registerCommands() {
 		Name:        "remove",
 		Description: "Remove a feed",
 		Handler:     b.handleRemoveCommand,
+		GuildID:     b.config.DiscordGuildId,
+	})
+	_ = b.parser.AddCommand(&switchboard.Command{
+		Name:        "pause",
+		Description: "Pause a feed from posting new items",
+		Handler:     b.handlePauseCommand,
+		GuildID:     b.config.DiscordGuildId,
+	})
+	_ = b.parser.AddCommand(&switchboard.Command{
+		Name:        "unpause",
+		Description: "Resume a paused feed",
+		Handler:     b.handleUnpauseCommand,
 		GuildID:     b.config.DiscordGuildId,
 	})
 }

--- a/pkg/bot/commands.go
+++ b/pkg/bot/commands.go
@@ -153,9 +153,7 @@ func (b *Bot) handleAddCommand(session *discordgo.Session, i *discordgo.Interact
 	}
 
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-		if err := b.watcher.RefreshFeed(ctx, newFeed, true); err != nil {
+		if err := b.watcher.RefreshFeed(context.Background(), newFeed, true); err != nil {
 			b.logger.Error("Failed to backfill new feed", "feed_id", newFeed.ID, "error", err)
 		}
 	}()
@@ -397,94 +395,6 @@ func (b *Bot) handleUnpauseCommand(session *discordgo.Session, i *discordgo.Inte
 	}
 }
 
-type refreshCommandArgs struct {
-	ID *int `description:"Optional ID of the feed to refresh. If omitted, refreshes all feeds."`
-}
-
-func (b *Bot) handleRefreshCommand(session *discordgo.Session, i *discordgo.InteractionCreate, args refreshCommandArgs) {
-	if err := session.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{},
-	}); err != nil {
-		b.logger.Error("Failed to defer interaction response", "error", err)
-		return
-	}
-
-	// Discord interaction tokens expire after 15 minutes; cap the refresh so we
-	// always have time to edit the response with the outcome.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-	defer cancel()
-
-	if args.ID != nil {
-		feed, err := b.Queries.GetFeedByID(ctx, int64(*args.ID))
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-					Content: utils.PtrTo(fmt.Sprintf("No feed found with ID `%d`.", *args.ID)),
-				})
-				return
-			}
-
-			b.logger.Error("Failed to get feed", "error", err)
-			_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-				Embeds: utils.PtrTo([]*discordgo.MessageEmbed{
-					{
-						Title:       "Failed to get feed",
-						Description: fmt.Sprintf("```\n%s\n```", err.Error()),
-						Color:       0xff0000,
-					},
-				}),
-			})
-			return
-		}
-
-		err = b.watcher.RefreshFeed(ctx, feed, false)
-		if err != nil {
-			b.logger.Error("Failed to refresh feed", "feed_id", feed.ID, "error", err)
-			_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-				Embeds: utils.PtrTo([]*discordgo.MessageEmbed{
-					{
-						Title:       "Failed to refresh feed",
-						Description: fmt.Sprintf("```\n%s\n```", err.Error()),
-						Color:       0xff0000,
-					},
-				}),
-			})
-			return
-		}
-
-		_, err = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Content: utils.PtrTo(fmt.Sprintf("Refreshed **%s**.", feed.Title)),
-		})
-		if err != nil {
-			b.logger.Error("Failed to respond to interaction", "error", err)
-		}
-		return
-	}
-
-	err := b.watcher.RefreshFeeds(ctx)
-	if err != nil {
-		b.logger.Error("Failed to refresh feeds", "error", err)
-		_, _ = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-			Embeds: utils.PtrTo([]*discordgo.MessageEmbed{
-				{
-					Title:       "Failed to refresh one or more feeds",
-					Description: fmt.Sprintf("```\n%s\n```", err.Error()),
-					Color:       0xff0000,
-				},
-			}),
-		})
-		return
-	}
-
-	_, err = session.InteractionResponseEdit(i.Interaction, &discordgo.WebhookEdit{
-		Content: utils.PtrTo("Refreshed all feeds."),
-	})
-	if err != nil {
-		b.logger.Error("Failed to respond to interaction", "error", err)
-	}
-}
-
 func (b *Bot) registerCommands() {
 	_ = b.parser.AddCommand(&switchboard.Command{
 		Name:        "add",
@@ -514,12 +424,6 @@ func (b *Bot) registerCommands() {
 		Name:        "unpause",
 		Description: "Resume a paused feed",
 		Handler:     b.handleUnpauseCommand,
-		GuildID:     b.config.DiscordGuildId,
-	})
-	_ = b.parser.AddCommand(&switchboard.Command{
-		Name:        "refresh",
-		Description: "Manually trigger a feed refresh (useful for testing)",
-		Handler:     b.handleRefreshCommand,
 		GuildID:     b.config.DiscordGuildId,
 	})
 }

--- a/pkg/database/migrations/000003_add_paused_until_to_feeds.down.sql
+++ b/pkg/database/migrations/000003_add_paused_until_to_feeds.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feeds DROP COLUMN paused_until;

--- a/pkg/database/migrations/000003_add_paused_until_to_feeds.up.sql
+++ b/pkg/database/migrations/000003_add_paused_until_to_feeds.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE feeds ADD COLUMN paused_until DATETIME;

--- a/pkg/database/models.go
+++ b/pkg/database/models.go
@@ -15,6 +15,7 @@ type Feed struct {
 	Url         string
 	FeedUrl     string
 	ChannelID   sql.NullString
+	PausedUntil sql.NullTime
 }
 
 type Post struct {

--- a/pkg/database/queries.sql
+++ b/pkg/database/queries.sql
@@ -11,10 +11,25 @@ WHERE id = ?;
 SELECT *
 FROM feeds;
 
+-- name: GetFeedByID :one
+SELECT *
+FROM feeds
+WHERE id = ?;
+
 -- name: GetFeedByUrl :one
 SELECT *
 FROM feeds
 WHERE feed_url = ?;
+
+-- name: PauseFeed :exec
+UPDATE feeds
+SET paused_until = ?
+WHERE id = ?;
+
+-- name: UnpauseFeed :exec
+UPDATE feeds
+SET paused_until = NULL
+WHERE id = ?;
 
 -- name: GetPosts :many
 SELECT post_guid

--- a/pkg/database/queries.sql.go
+++ b/pkg/database/queries.sql.go
@@ -13,7 +13,7 @@ import (
 const createFeed = `-- name: CreateFeed :one
 INSERT INTO feeds (title, description, url, feed_url, channel_id)
 VALUES (?, ?, ?, ?, ?)
-RETURNING id, title, description, url, feed_url, channel_id
+RETURNING id, title, description, url, feed_url, channel_id, paused_until
 `
 
 type CreateFeedParams struct {
@@ -40,6 +40,7 @@ func (q *Queries) CreateFeed(ctx context.Context, arg CreateFeedParams) (Feed, e
 		&i.Url,
 		&i.FeedUrl,
 		&i.ChannelID,
+		&i.PausedUntil,
 	)
 	return i, err
 }
@@ -87,8 +88,29 @@ func (q *Queries) DeleteFeed(ctx context.Context, id int64) error {
 	return err
 }
 
+const getFeedByID = `-- name: GetFeedByID :one
+SELECT id, title, description, url, feed_url, channel_id, paused_until
+FROM feeds
+WHERE id = ?
+`
+
+func (q *Queries) GetFeedByID(ctx context.Context, id int64) (Feed, error) {
+	row := q.db.QueryRowContext(ctx, getFeedByID, id)
+	var i Feed
+	err := row.Scan(
+		&i.ID,
+		&i.Title,
+		&i.Description,
+		&i.Url,
+		&i.FeedUrl,
+		&i.ChannelID,
+		&i.PausedUntil,
+	)
+	return i, err
+}
+
 const getFeedByUrl = `-- name: GetFeedByUrl :one
-SELECT id, title, description, url, feed_url, channel_id
+SELECT id, title, description, url, feed_url, channel_id, paused_until
 FROM feeds
 WHERE feed_url = ?
 `
@@ -103,12 +125,13 @@ func (q *Queries) GetFeedByUrl(ctx context.Context, feedUrl string) (Feed, error
 		&i.Url,
 		&i.FeedUrl,
 		&i.ChannelID,
+		&i.PausedUntil,
 	)
 	return i, err
 }
 
 const getFeeds = `-- name: GetFeeds :many
-SELECT id, title, description, url, feed_url, channel_id
+SELECT id, title, description, url, feed_url, channel_id, paused_until
 FROM feeds
 `
 
@@ -128,6 +151,7 @@ func (q *Queries) GetFeeds(ctx context.Context) ([]Feed, error) {
 			&i.Url,
 			&i.FeedUrl,
 			&i.ChannelID,
+			&i.PausedUntil,
 		); err != nil {
 			return nil, err
 		}
@@ -169,4 +193,31 @@ func (q *Queries) GetPosts(ctx context.Context, feedID int64) ([]string, error) 
 		return nil, err
 	}
 	return items, nil
+}
+
+const pauseFeed = `-- name: PauseFeed :exec
+UPDATE feeds
+SET paused_until = ?
+WHERE id = ?
+`
+
+type PauseFeedParams struct {
+	PausedUntil sql.NullTime
+	ID          int64
+}
+
+func (q *Queries) PauseFeed(ctx context.Context, arg PauseFeedParams) error {
+	_, err := q.db.ExecContext(ctx, pauseFeed, arg.PausedUntil, arg.ID)
+	return err
+}
+
+const unpauseFeed = `-- name: UnpauseFeed :exec
+UPDATE feeds
+SET paused_until = NULL
+WHERE id = ?
+`
+
+func (q *Queries) UnpauseFeed(ctx context.Context, id int64) error {
+	_, err := q.db.ExecContext(ctx, unpauseFeed, id)
+	return err
 }

--- a/pkg/feeds/watcher.go
+++ b/pkg/feeds/watcher.go
@@ -152,6 +152,8 @@ func (f *FeedWatcher) RefreshFeed(feed database.Feed, isBackfill bool) error {
 		return iTime.Before(*jTime)
 	})
 
+	isPaused := feed.PausedUntil.Valid && feed.PausedUntil.Time.After(time.Now())
+
 	for _, item := range feedData.Items {
 		if _, seen := seenPostsMap[item.GUID]; seen {
 			continue
@@ -160,7 +162,8 @@ func (f *FeedWatcher) RefreshFeed(feed database.Feed, isBackfill bool) error {
 		f.logger.Debug("New item found", "feed_id", feed.ID, "item_guid", item.GUID)
 
 		var postMsgId string
-		if f.cfg.ShowBackfill || !isBackfill {
+		shouldPost := (f.cfg.ShowBackfill || !isBackfill) && !isPaused
+		if shouldPost {
 			postMsgId, err = f.postItem(feed, item)
 			if err != nil {
 				return fmt.Errorf("failed to post item: %w", err)

--- a/pkg/feeds/watcher.go
+++ b/pkg/feeds/watcher.go
@@ -128,9 +128,17 @@ func (f *FeedWatcher) postItem(ctx context.Context, feed database.Feed, item *go
 	return postMsg.ID, nil
 }
 
+// refreshFeedTimeout bounds how long a single feed refresh can take. A parse
+// plus a handful of Discord posts should complete in seconds; this is just a
+// safety net against a stuck feed or hung Discord call.
+const refreshFeedTimeout = 2 * time.Minute
+
 func (f *FeedWatcher) RefreshFeed(ctx context.Context, feed database.Feed, isBackfill bool) error {
 	f.refreshMu.Lock()
 	defer f.refreshMu.Unlock()
+
+	ctx, cancel := context.WithTimeout(ctx, refreshFeedTimeout)
+	defer cancel()
 
 	f.logger.Debug("Refreshing feed", "feed_id", feed.ID, "feed_url", feed.FeedUrl)
 

--- a/pkg/feeds/watcher.go
+++ b/pkg/feeds/watcher.go
@@ -186,7 +186,7 @@ func (f *FeedWatcher) RefreshFeed(feed database.Feed, isBackfill bool) error {
 	return nil
 }
 
-func (f *FeedWatcher) refreshFeeds() error {
+func (f *FeedWatcher) RefreshFeeds() error {
 	feeds, err := f.Queries.GetFeeds(f.watcherCtx)
 	if err != nil {
 		return fmt.Errorf("failed to get feeds: %w", err)
@@ -211,7 +211,7 @@ func (f *FeedWatcher) refreshFeeds() error {
 func (f *FeedWatcher) scheduledTask() {
 	f.logger.Debug("Refreshing feeds")
 
-	err := f.refreshFeeds()
+	err := f.RefreshFeeds()
 	if err != nil {
 		f.logger.Error("Failed to refresh feeds", "error", err)
 		return

--- a/pkg/feeds/watcher.go
+++ b/pkg/feeds/watcher.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 
 	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
@@ -33,10 +32,6 @@ type FeedWatcher struct {
 	watcherCtx    context.Context
 	stopWatcher   context.CancelFunc
 	stoppedChan   chan struct{}
-
-	// refreshMu serializes refresh passes so the scheduled ticker and manual
-	// refresh invocations don't race on the (feed_id, post_guid) primary key.
-	refreshMu sync.Mutex
 }
 
 func (f *FeedWatcher) postItem(ctx context.Context, feed database.Feed, item *gofeed.Item) (string, error) {
@@ -134,9 +129,6 @@ func (f *FeedWatcher) postItem(ctx context.Context, feed database.Feed, item *go
 const refreshFeedTimeout = 2 * time.Minute
 
 func (f *FeedWatcher) RefreshFeed(ctx context.Context, feed database.Feed, isBackfill bool) error {
-	f.refreshMu.Lock()
-	defer f.refreshMu.Unlock()
-
 	ctx, cancel := context.WithTimeout(ctx, refreshFeedTimeout)
 	defer cancel()
 

--- a/pkg/feeds/watcher.go
+++ b/pkg/feeds/watcher.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	htmltomarkdown "github.com/JohannesKaufmann/html-to-markdown/v2"
@@ -32,9 +33,13 @@ type FeedWatcher struct {
 	watcherCtx    context.Context
 	stopWatcher   context.CancelFunc
 	stoppedChan   chan struct{}
+
+	// refreshMu serializes refresh passes so the scheduled ticker and manual
+	// refresh invocations don't race on the (feed_id, post_guid) primary key.
+	refreshMu sync.Mutex
 }
 
-func (f *FeedWatcher) postItem(feed database.Feed, item *gofeed.Item) (string, error) {
+func (f *FeedWatcher) postItem(ctx context.Context, feed database.Feed, item *gofeed.Item) (string, error) {
 	f.logger.Debug("Posting item", "feed_id", feed.ID, "item_guid", item.GUID)
 
 	channelID := f.cfg.DiscordChannelId
@@ -104,7 +109,7 @@ func (f *FeedWatcher) postItem(feed database.Feed, item *gofeed.Item) (string, e
 	postMsg, err := f.Session.ChannelMessageSendEmbed(
 		channelID,
 		embed,
-		discordgo.WithContext(f.watcherCtx),
+		discordgo.WithContext(ctx),
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to send message: %w", err)
@@ -115,7 +120,7 @@ func (f *FeedWatcher) postItem(feed database.Feed, item *gofeed.Item) (string, e
 		postMsg.ID,
 		truncatedTitleForThread,
 		4320,
-		discordgo.WithContext(f.watcherCtx),
+		discordgo.WithContext(ctx),
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to start thread: %w", err)
@@ -123,10 +128,13 @@ func (f *FeedWatcher) postItem(feed database.Feed, item *gofeed.Item) (string, e
 	return postMsg.ID, nil
 }
 
-func (f *FeedWatcher) RefreshFeed(feed database.Feed, isBackfill bool) error {
+func (f *FeedWatcher) RefreshFeed(ctx context.Context, feed database.Feed, isBackfill bool) error {
+	f.refreshMu.Lock()
+	defer f.refreshMu.Unlock()
+
 	f.logger.Debug("Refreshing feed", "feed_id", feed.ID, "feed_url", feed.FeedUrl)
 
-	seenPosts, err := f.Queries.GetPosts(f.watcherCtx, feed.ID)
+	seenPosts, err := f.Queries.GetPosts(ctx, feed.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get seen posts for feed %d: %w", feed.ID, err)
 	}
@@ -135,7 +143,7 @@ func (f *FeedWatcher) RefreshFeed(feed database.Feed, isBackfill bool) error {
 		seenPostsMap[post] = struct{}{}
 	}
 
-	feedData, err := f.parser.ParseURLWithContext(feed.FeedUrl, f.watcherCtx)
+	feedData, err := f.parser.ParseURLWithContext(feed.FeedUrl, ctx)
 	if err != nil {
 		return fmt.Errorf("failed to parse feed: %w", err)
 	}
@@ -164,13 +172,13 @@ func (f *FeedWatcher) RefreshFeed(feed database.Feed, isBackfill bool) error {
 		var postMsgId string
 		shouldPost := (f.cfg.ShowBackfill || !isBackfill) && !isPaused
 		if shouldPost {
-			postMsgId, err = f.postItem(feed, item)
+			postMsgId, err = f.postItem(ctx, feed, item)
 			if err != nil {
 				return fmt.Errorf("failed to post item: %w", err)
 			}
 		}
 
-		err = f.Queries.CreatePost(f.watcherCtx, database.CreatePostParams{
+		err = f.Queries.CreatePost(ctx, database.CreatePostParams{
 			PostGuid:    item.GUID,
 			FeedID:      feed.ID,
 			Title:       item.Title,
@@ -186,8 +194,8 @@ func (f *FeedWatcher) RefreshFeed(feed database.Feed, isBackfill bool) error {
 	return nil
 }
 
-func (f *FeedWatcher) RefreshFeeds() error {
-	feeds, err := f.Queries.GetFeeds(f.watcherCtx)
+func (f *FeedWatcher) RefreshFeeds(ctx context.Context) error {
+	feeds, err := f.Queries.GetFeeds(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get feeds: %w", err)
 	}
@@ -195,7 +203,7 @@ func (f *FeedWatcher) RefreshFeeds() error {
 	var feedErrors []error
 
 	for _, feed := range feeds {
-		err := f.RefreshFeed(feed, false)
+		err := f.RefreshFeed(ctx, feed, false)
 		if err != nil {
 			feedErrors = append(feedErrors, fmt.Errorf("failed to refresh feed %d: %w", feed.ID, err))
 		}
@@ -211,7 +219,7 @@ func (f *FeedWatcher) RefreshFeeds() error {
 func (f *FeedWatcher) scheduledTask() {
 	f.logger.Debug("Refreshing feeds")
 
-	err := f.RefreshFeeds()
+	err := f.RefreshFeeds(f.watcherCtx)
 	if err != nil {
 		f.logger.Error("Failed to refresh feeds", "error", err)
 		return


### PR DESCRIPTION
sometimes a feed might get loud, if its say, linked to someone's letterboxed doing a backlog crawl of movies they've seen

this lets them pause their feed without removing it

tested:
<img width="633" height="530" alt="Screenshot 2026-06-08 at 9 25 04 PM" src="https://github.com/user-attachments/assets/99a53902-d078-4d53-85c8-6da1fa5b84c1" />

this also adds a `/refresh {optional id}` command, was useful for testing this, kept it in so folks impatient about an update can refresh manually

also did a quality check pass via an llm subagent reviewing the diff addressed two rfindings:

- threaded `context.Context` through the refresh path so manual refreshes get their own timeout instead of riding on the watcher's shutdown context
- added a mutex so the scheduled ticker and `/refresh` can't race each other on the `(feed_id, post_guid)` primary key